### PR TITLE
Add landing pages and external assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,21 @@ Use it on:
 Let's share the movement. AI for business, AI for the people.
 
 ---
+
+## ℹ️ Project Setup
+
+The site consists of simple static pages. Open `index.html` in your browser to
+get started or serve the folder with any static hosting solution.
+
+### Contact Form
+
+The contact form sends submissions via [FormSubmit](https://formsubmit.co) and
+can optionally notify a Telegram chat. Edit `js/config.js` and set `CHAT_ID` and
+`BOT_TOKEN` with your Telegram bot credentials.
+
+### Assets
+
+All styles are in `css/styles.css` and JavaScript files live in the `js`
+directory. Feel free to add more assets or split code as the project grows.
+
+---

--- a/contact.html
+++ b/contact.html
@@ -1,19 +1,10 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Contact Campeón GPT</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body { font-family: Arial, sans-serif; padding: 2rem; background: #f4f4f4; }
-    form { background: #fff; padding: 2rem; max-width: 500px; margin: auto; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
-    h2 { text-align: center; }
-    label { display: block; margin-top: 1rem; }
-    input, textarea, select { width: 100%; padding: 0.75rem; margin-top: 0.5rem; border-radius: 5px; border: 1px solid #ccc; }
-    button { margin-top: 1.5rem; padding: 1rem; width: 100%; background: #1e90ff; color: white; border: none; border-radius: 5px; font-size: 1rem; }
-    button:hover { background: #0077cc; }
-  </style>
+  <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
   <form action="https://formsubmit.co/sahidattaf@gmail.com" method="POST" onsubmit="notifyTelegram();">
@@ -47,20 +38,7 @@
     <button type="submit">📨 Send Request</button>
   </form>
 
-  <script>
-    function notifyTelegram() {
-      const data = {
-        chat_id: "YOUR_CHAT_ID",
-        text: "🚀 New Campeón GPT request submitted via site!",
-        parse_mode: "HTML"
-      };
-
-      fetch("https://api.telegram.org/botYOUR_BOT_TOKEN/sendMessage", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data)
-      });
-    }
-  </script>
+  <script src="js/config.js"></script>
+  <script src="js/contact.js"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; padding: 2rem; background: #f4f4f4; }
+form { background: #fff; padding: 2rem; max-width: 500px; margin: auto; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+h2 { text-align: center; }
+label { display: block; margin-top: 1rem; }
+input, textarea, select { width: 100%; padding: 0.75rem; margin-top: 0.5rem; border-radius: 5px; border: 1px solid #ccc; }
+button { margin-top: 1.5rem; padding: 1rem; width: 100%; background: #1e90ff; color: white; border: none; border-radius: 5px; font-size: 1rem; }
+button:hover { background: #0077cc; }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Campeón GPT</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>Welcome to Campeón GPT</h1>
+  <p>Discover our suite of specialized GPT tools to empower your business.</p>
+  <p><a href="contact.html">Contact us</a> to learn more or request access.</p>
+  <nav>
+    <a href="index_es.html">Español</a> |
+    <a href="index_nl.html">Nederlands</a> |
+    <a href="index_pa.html">Papiamento</a>
+  </nav>
+</body>
+</html>

--- a/index_es.html
+++ b/index_es.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Campeón GPT</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>Bienvenido a Campeón GPT</h1>
+  <p>Descubre nuestra suite de herramientas GPT especializadas para potenciar tu negocio.</p>
+  <p><a href="contact.html">Contáctanos</a> para saber más o solicitar acceso.</p>
+  <nav>
+    <a href="index.html">English</a> |
+    <a href="index_nl.html">Nederlands</a> |
+    <a href="index_pa.html">Papiamento</a>
+  </nav>
+</body>
+</html>

--- a/index_nl.html
+++ b/index_nl.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <title>Campeón GPT</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>Welkom bij Campeón GPT</h1>
+  <p>Ontdek onze suite van gespecialiseerde GPT-tools om uw bedrijf te versterken.</p>
+  <p><a href="contact.html">Neem contact met ons op</a> voor meer informatie of toegang.</p>
+  <nav>
+    <a href="index.html">English</a> |
+    <a href="index_es.html">Español</a> |
+    <a href="index_pa.html">Papiamento</a>
+  </nav>
+</body>
+</html>

--- a/index_pa.html
+++ b/index_pa.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="pap">
+<head>
+  <meta charset="UTF-8">
+  <title>Campeón GPT</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <h1>Bon bini na Campeón GPT</h1>
+  <p>Deskubrí nos suite di GPT spesialisa pa fortaleka bo negoshi.</p>
+  <p><a href="contact.html">Tene kontaktu ku nos</a> pa mas infó of pa pidi akses.</p>
+  <nav>
+    <a href="index.html">English</a> |
+    <a href="index_es.html">Español</a> |
+    <a href="index_nl.html">Nederlands</a>
+  </nav>
+</body>
+</html>

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,3 @@
+// Replace the placeholders below with your Telegram bot details
+const CHAT_ID = "YOUR_CHAT_ID";
+const BOT_TOKEN = "YOUR_BOT_TOKEN";

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,13 @@
+function notifyTelegram() {
+  const data = {
+    chat_id: CHAT_ID,
+    text: "🚀 New Campeón GPT request submitted via site!",
+    parse_mode: "HTML"
+  };
+
+  fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data)
+  });
+}


### PR DESCRIPTION
## Summary
- create basic landing pages in English, Spanish, Dutch and Papiamento
- move contact page styles and script into `css` and `js` folders
- add placeholders for Telegram bot configuration
- document project setup and contact form configuration in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842e5001e20832abe8944ed75d76172